### PR TITLE
feat(exams): POST /exams genera preguntas cuando el formulario es llenado y los datos del examen son guardados cuando se obtiene una respuesta exitosa de la IA

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -949,6 +950,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/backend/src/core/ai/ai.config.ts
+++ b/backend/src/core/ai/ai.config.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AiConfigService {
+  readonly apiKey = process.env.GEMINI_API_KEY ?? process.env.AI_API_KEY ?? '';
+  readonly model  = process.env.AI_MODEL ?? 'gemini-2.0-flash-exp';
+  readonly maxOutputTokens = Number(process.env.AI_MAX_OUTPUT_TOKENS ?? 512);
+  readonly temperature = Number(process.env.AI_TEMPERATURE ?? 0.2);
+
+  ensure() {
+    if (!this.apiKey) {
+      throw new Error('Falta la API key de IA. Define GEMINI_API_KEY o AI_API_KEY en .env');
+    }
+  }
+}

--- a/backend/src/modules/exams/application/commands/generate-questions.command.ts
+++ b/backend/src/modules/exams/application/commands/generate-questions.command.ts
@@ -1,0 +1,41 @@
+import { Inject } from '@nestjs/common';
+import { ExamFactory } from '../../domain/entities/exam.factory';
+import { EXAM_AI_GENERATOR } from '../../tokens';
+import type { AIQuestionGeneratorPort } from '../../domain/ports/ai-question-generator.port';
+
+export class GenerateQuestionsCommand {
+  constructor(
+    public readonly subject: string,
+    public readonly difficulty: 'fácil' | 'medio' | 'difícil',
+    public readonly totalQuestions: number,
+    public readonly reference?: string | null,
+    public readonly preferredType?: 'open' | 'multiple_choice' | 'mixed',
+  ) {}
+}
+
+export class GenerateQuestionsCommandHandler {
+  constructor(
+    @Inject(EXAM_AI_GENERATOR) private readonly ai: AIQuestionGeneratorPort,
+  ) {}
+
+  async execute(cmd: GenerateQuestionsCommand) {
+    ExamFactory.create({
+      subject: cmd.subject,
+      difficulty: cmd.difficulty,
+      attempts: 1, 
+      totalQuestions: cmd.totalQuestions,
+      timeMinutes: 1,
+      reference: cmd.reference ?? null,
+    });
+
+    const questions = await this.ai.generate({
+      subject: cmd.subject,
+      difficulty: cmd.difficulty,
+      totalQuestions: cmd.totalQuestions,
+      reference: cmd.reference ?? null,
+      preferredType: cmd.preferredType ?? 'mixed',
+    });
+
+    return questions.map(q => q.toJSON());
+  }
+}

--- a/backend/src/modules/exams/domain/entities/question.entity.ts
+++ b/backend/src/modules/exams/domain/entities/question.entity.ts
@@ -1,0 +1,22 @@
+export type QuestionType = 'open' | 'multiple_choice';
+
+export class Question {
+  constructor(
+    public readonly type: QuestionType,
+    public readonly text: string,
+    public readonly options?: string[] | null,   
+  ) {
+    if (!text?.trim()) throw new Error('Question.text es obligatorio');
+    if (type === 'multiple_choice' && (!options || options.length < 2)) {
+      throw new Error('Multiple choice requiere al menos 2 opciones.');
+    }
+  }
+
+  toJSON() {
+    return {
+      type: this.type,
+      text: this.text,
+      options: this.options ?? null,
+    };
+  }
+}

--- a/backend/src/modules/exams/domain/ports/ai-question-generator.port.ts
+++ b/backend/src/modules/exams/domain/ports/ai-question-generator.port.ts
@@ -1,0 +1,11 @@
+import { Question } from '../entities/question.entity';
+
+export interface AIQuestionGeneratorPort {
+  generate(params: {
+    subject: string;
+    difficulty: 'fácil' | 'medio' | 'difícil';
+    totalQuestions: number;
+    reference?: string | null;
+    preferredType?: 'open' | 'multiple_choice' | 'mixed';
+  }): Promise<Question[]>;
+}

--- a/backend/src/modules/exams/domain/services/prompt-builder.service.ts
+++ b/backend/src/modules/exams/domain/services/prompt-builder.service.ts
@@ -1,0 +1,34 @@
+export class PromptBuilder {
+  static build(p: {
+    subject: string;
+    difficulty: 'fácil'|'medio'|'difícil';
+    totalQuestions: number;
+    reference?: string|null;
+    preferredType?: 'open'|'multiple_choice'|'mixed';
+  }): string {
+    return [
+      `Genera exactamente ${p.totalQuestions} preguntas de examen sobre "${p.subject}".`,
+      `Dificultad: ${p.difficulty}.`,
+      `Referencia: ${p.reference ?? 'ninguna'}.`,
+      `Tipo preferido: ${p.preferredType ?? 'mixed'}.`,
+      ``,
+      `DEVUELVE ÚNICAMENTE JSON VÁLIDO (application/json), sin texto adicional, sin comentarios, sin explicaciones, sin markdown.`,
+      `El resultado debe ser un ARRAY JSON, no un objeto, con esta forma EXACTA (sin comas finales):`,
+      `[`,
+      `  {`,
+      `    "type": "open" | "multiple_choice",`,
+      `    "text": "string no vacía",`,
+      `    "options": ["string","string","string","string"] (solo si "type" = "multiple_choice", 3 a 5 opciones)`,
+      `  }`,
+      `]`,
+      ``,
+      `REGLAS ESTRICTAS:`,
+      `- No incluyas nada fuera del JSON (ni encabezados, ni notas).`,
+      `- "text" debe ser legible, sin HTML, sin saltos de línea excesivos.`,
+      `- Si "type" = "open": NO incluyas "options".`,
+      `- Si "type" = "multiple_choice": incluye entre 3 y 5 opciones, todas distintas, sin la respuesta marcada.`,
+      `- Usa comillas dobles estándar, sin comas colgantes, sin valores undefined.`,
+      `- El JSON DEBE parsear correctamente con JSON.parse.`,
+    ].join('\n');
+  }
+}

--- a/backend/src/modules/exams/exams.module.ts
+++ b/backend/src/modules/exams/exams.module.ts
@@ -1,16 +1,24 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../../core/prisma/prisma.module';
-import { EXAM_REPO } from './tokens';
+import { EXAM_REPO, EXAM_AI_GENERATOR } from './tokens';
 import { ExamPrismaRepository } from './infrastructure/persistence/exam.prisma.repository';
 import { ExamsController } from './infrastructure/http/exams.controller';
 import { CreateExamCommandHandler } from './application/commands/create-exam.command';
+import { GenerateQuestionsCommandHandler } from './application/commands/generate-questions.command';
+import { AIQuestionGenerator } from './infrastructure/ai/ai-question.generator';
+import { AiConfigService } from '../../core/ai/ai.config';
 
 @Module({
   imports: [PrismaModule],
   controllers: [ExamsController],
   providers: [
+    // persistencia
     { provide: EXAM_REPO, useClass: ExamPrismaRepository },
+    // adaptador IA
+    { provide: EXAM_AI_GENERATOR, useClass: AIQuestionGenerator },
+    AiConfigService,
     CreateExamCommandHandler,
+    GenerateQuestionsCommandHandler,
   ],
 })
 export class ExamsModule {}

--- a/backend/src/modules/exams/infrastructure/ai/ai-question.generator.ts
+++ b/backend/src/modules/exams/infrastructure/ai/ai-question.generator.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import type { AIQuestionGeneratorPort } from '../../domain/ports/ai-question-generator.port';
+import { Question } from '../../domain/entities/question.entity';
+import { PromptBuilder } from '../../domain/services/prompt-builder.service';
+import { AiConfigService } from '../../../../core/ai/ai.config';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+function parseJsonArrayStrictOrCut(text: string): any[] {
+  try { return JSON.parse(text); } catch {}
+  const cleaned = text.replace(/```json|```/g, '').trim();
+  try { return JSON.parse(cleaned); } catch {}
+  const end = cleaned.lastIndexOf(']');
+  if (end !== -1) {
+    const cut = cleaned.slice(0, end + 1);
+    try { return JSON.parse(cut); } catch {}
+  }
+  throw new Error(`AI response no es JSON válido: ${text}`);
+}
+
+@Injectable()
+export class AIQuestionGenerator implements AIQuestionGeneratorPort {
+  private readonly model: ReturnType<GoogleGenerativeAI['getGenerativeModel']>;
+
+  constructor(private readonly cfg: AiConfigService) {
+    this.cfg.ensure();
+    const genAI = new GoogleGenerativeAI(this.cfg.apiKey);
+    this.model = genAI.getGenerativeModel({
+      model: this.cfg.model || 'gemini-1.5-pro-latest',
+    });
+  }
+
+  async generate(params: {
+    subject: string;
+    difficulty: 'fácil' | 'medio' | 'difícil';
+    totalQuestions: number;
+    reference?: string | null;
+    preferredType?: 'open' | 'multiple_choice' | 'mixed';
+  }): Promise<Question[]> {
+    const prompt = PromptBuilder.build(params);
+
+    const resp = await this.model.generateContent({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: {
+        maxOutputTokens: this.cfg.maxOutputTokens ?? 1024, 
+        temperature: this.cfg.temperature ?? 0.2,
+        responseMimeType: 'application/json',
+      },
+    });
+
+    let contentText: string =
+      resp?.response?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    if (!contentText) throw new Error('AI response vacío.');
+
+    contentText = contentText.replace(/```json|```/g, '').trim();
+
+    const rawList = parseJsonArrayStrictOrCut(contentText);
+
+    return rawList.map((q: any) => {
+      const type = q?.type === 'multiple_choice' ? 'multiple_choice' : 'open';
+      const text = String(q?.text ?? '').trim();
+      const options = type === 'multiple_choice' ? (q?.options ?? []) : null;
+      return new Question(type, text, options);
+    });
+  }
+}

--- a/backend/src/modules/exams/infrastructure/http/dtos/generate-questions.dto.ts
+++ b/backend/src/modules/exams/infrastructure/http/dtos/generate-questions.dto.ts
@@ -1,0 +1,25 @@
+import { IsIn, IsInt, IsNotEmpty, IsOptional, IsPositive, IsString, MaxLength } from 'class-validator';
+
+export class GenerateQuestionsDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  subject!: string;
+
+  @IsString()
+  @IsIn(['fácil', 'medio', 'difícil'])
+  difficulty!: 'fácil' | 'medio' | 'difícil';
+
+  @IsInt()
+  @IsPositive()
+  totalQuestions!: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  reference?: string;
+
+  @IsOptional()
+  @IsIn(['open', 'multiple_choice', 'mixed'])
+  preferredType?: 'open' | 'multiple_choice' | 'mixed';
+}

--- a/backend/src/modules/exams/tokens.ts
+++ b/backend/src/modules/exams/tokens.ts
@@ -1,1 +1,2 @@
 export const EXAM_REPO = Symbol('EXAM_REPO');
+export const EXAM_AI_GENERATOR = Symbol('EXAM_AI_GENERATOR');


### PR DESCRIPTION
Se puede comprobar la funcionalidad a traves de postman, con el metodo POST con localhost:3000/exams y un json de entrada como el siguiente:
{
  "subject": "Programacion I",
  "difficulty": "medio",
  "reference": "Cap. 3 y 4",
  "attempts": 1,
  "totalQuestions": 4,
  "timeMinutes": 45
}

y deberia dar un json de salida cn las preguntas generadas por la IA y ademas los datos del examen deberian ser guardados en la base de datos