### PR TITLE
feat(exam-controller): use backend response model

### DIFF
--- a/client/src/pages/exams/ExamCreatePage.tsx
+++ b/client/src/pages/exams/ExamCreatePage.tsx
@@ -217,7 +217,7 @@ export default function ExamsCreatePage() {
       breadcrumbs={[
         { label: 'Home', href: '/' },
         { label: 'Exámenes', href: '/exam' },
-        { label: 'Crear', href: '/exams/create' },
+        { label: 'Crear' },
       ]}
     >
       <div className="pantalla-scroll">


### PR DESCRIPTION
controller was changed so every endpoint uses this response model:
export interface httpDTO {
    code: number;
    error: string;
    correlation_id: string;
    data: any;
    description: string;
    path: string;
}

and now breadcrumb Crear doesn't have an href anymore, so you can't refresh from header anymore
<img width="324" height="148" alt="image" src="https://github.com/user-attachments/assets/fc6265bd-d96a-4610-acb7-97af6453d159" />
