### PR TITLE
feat[# 52]:Adding a GET endpoint to visualize saved exams + 2 pdf visualization ways

### DIFF
--- a/backend/prisma/migrations/20250908045738_add_savedexam_exam_relation_nullable/migration.sql
+++ b/backend/prisma/migrations/20250908045738_add_savedexam_exam_relation_nullable/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[examId]` on the table `SavedExam` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."SavedExam" ADD COLUMN     "examId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SavedExam_examId_key" ON "public"."SavedExam"("examId");
+
+-- AddForeignKey
+ALTER TABLE "public"."SavedExam" ADD CONSTRAINT "SavedExam_examId_fkey" FOREIGN KEY ("examId") REFERENCES "public"."Exam"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -319,6 +319,8 @@ model Exam {
   questions       ExamQuestion[]
 
   @@index([subject])
+
+  savedExam      SavedExam?
 }
 
 // === Preguntas de Examen ===
@@ -339,6 +341,9 @@ model SavedExam {
   title     String
   content   Json
   status    ExamStorageStatus @default(Guardado)
+
+  examId    String?           @unique
+  exam      Exam?             @relation(fields: [examId], references: [id], onDelete: Cascade)
 
   // FK “lógicas” (sin relación Prisma)
   courseId  String

--- a/backend/src/modules/deepseek/domain/ports/deepseek.port.ts
+++ b/backend/src/modules/deepseek/domain/ports/deepseek.port.ts
@@ -21,5 +21,5 @@ export interface DeepseekPort {
 
   generateMultOptionTest(
     topico: string,
-  ): Promise<MultipleSelectionTestResponse>;
+  ): Promise<MultipleSelectionResponse>;
 }

--- a/backend/src/modules/deepseek/infrastructure/ds.adapter.ts
+++ b/backend/src/modules/deepseek/infrastructure/ds.adapter.ts
@@ -229,7 +229,7 @@ export class DsAdapter implements DeepseekPort {
   }
   async generateMultOptionTest(
     topico: string,
-  ): Promise<MultipleSelectionTestResponse> {
+  ): Promise<MultipleSelectionResponse> {
     try {
       const vars: Record<string, string> = {
         topico: topico,
@@ -263,7 +263,7 @@ export class DsAdapter implements DeepseekPort {
       }
       const response = JSON.parse(
         responseContent,
-      ) as MultipleSelectionTestResponse;
+      ) as MultipleSelectionResponse;
       return response;
     } catch (error) {
       console.error('OpenAI Error in generateMultipleTestSelection:', error);

--- a/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
+++ b/backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { EXAM_REPO, EXAM_QUESTION_REPO, SAVED_EXAM_REPO } from '../../tokens';
+import type { ExamRepositoryPort } from '../../domain/ports/exam.repository.port';
+import type { ExamQuestionRepositoryPort } from '../../domain/ports/exam-question.repository.port';
+import type { SavedExamRepositoryPort } from '../../domain/ports/saved-exam.repository.port';
+import { NotFoundError, UnauthorizedError } from 'src/shared/handler/errors';
+
+export type GetExamByIdQuery = { examId: string; teacherId: string };
+
+@Injectable()
+export class GetExamByIdUseCase {
+    constructor(
+        private readonly prisma: PrismaService,
+        @Inject(EXAM_REPO) private readonly examRepo: ExamRepositoryPort,
+        @Inject(EXAM_QUESTION_REPO) private readonly questionRepo: ExamQuestionRepositoryPort,
+        @Inject(SAVED_EXAM_REPO) private readonly savedRepo: SavedExamRepositoryPort,
+    ) {}
+
+    async execute(q: GetExamByIdQuery) {
+    // SavedExam binds examId to a teacher and course (ownership)
+        const saved = await this.savedRepo.findByExamId(q.examId);
+        if (!saved) throw new NotFoundError('Examen no encontrado');
+        if (saved.teacherId !== q.teacherId) throw new UnauthorizedError('Acceso no autorizado');
+
+    const exam = await this.examRepo.findById(q.examId);
+        if (!exam) throw new NotFoundError('Examen no encontrado');
+
+    const questions = await this.questionRepo.listByExam(q.examId);
+
+    const raw = typeof (exam as any).toJSON === 'function' ? (exam as any).toJSON() : exam as any;
+    const distribution =
+        'mcqCount' in raw ||
+        'trueFalseCount' in raw ||
+        'openAnalysisCount' in raw ||
+        'openExerciseCount' in raw
+    ? {
+        multiple_choice: raw.mcqCount ?? 0,
+        true_false: raw.trueFalseCount ?? 0,
+        open_analysis: raw.openAnalysisCount ?? 0,
+        open_exercise: raw.openExerciseCount ?? 0,
+    }
+    : null;
+
+    // JSON ready for FE
+    const base = exam.toJSON();
+        return {
+            id: exam.id,
+            title: saved.title,
+            date: saved.createdAt,
+            status: saved.status,         // Guardado | Publicado
+            subject: base.subject,
+            difficulty: base.difficulty,
+            totalQuestions: base.totalQuestions,
+            timeMinutes: base.timeMinutes,
+            reference: base.reference ?? null,
+            distribution,
+            questions: questions.map(q => ({
+                id: q.id,
+                kind: q.kind,                // MCQ | TRUE_FALSE | OPEN_ANALYSIS | OPEN_EXERCISE
+                text: q.text,
+                options: q.options ?? null,
+                correctOptionIndex: q.correctOptionIndex ?? null,
+                correctBoolean: q.correctBoolean ?? null,
+                expectedAnswer: q.expectedAnswer ?? null,
+                order: q.order,
+            })),
+        };
+    }
+}

--- a/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/exam-question.repository.port.ts
@@ -20,4 +20,5 @@ export interface ExamQuestionRepositoryPort {
 
   findById(id: string): Promise<ExamQuestion | null>;
   update(id: string, patch: UpdateExamQuestionPatch): Promise<ExamQuestion>;
+  listByExam(examId: string): Promise<ExamQuestion[]>;
 }

--- a/backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts
+++ b/backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts
@@ -17,7 +17,21 @@ export interface SavedExamDTO {
   source?: 'saved' | 'hardcoded';
 }
 
+export type SavedExamStatus = 'Guardado' | 'Publicado';
+
+export type SavedExamReadModel = {
+  id: number;
+  title: string;
+  content: unknown; 
+  status: SavedExamStatus;  
+  courseId: string;
+  teacherId: string;
+  createdAt: Date;
+  examId: string | null; 
+};
+
 export interface SavedExamRepositoryPort {
   save(data: SaveApprovedExamInput): Promise<SavedExamDTO>;
   listByCourse(courseId: string, teacherId?: string): Promise<SavedExamDTO[]>;
+  findByExamId(examId: string): Promise<SavedExamReadModel | null>;
 }

--- a/backend/src/modules/exams/exams.module.ts
+++ b/backend/src/modules/exams/exams.module.ts
@@ -17,7 +17,9 @@ import { ApproveExamCommandHandler } from './application/commands/approve-exam.h
 import { SavedExamPrismaRepository } from './infrastructure/persistence/saved-exam.prisma.repository';
 import { SaveApprovedExamUseCase } from './application/commands/save-approved-exam.usecase';
 import { ListCourseExamsUseCase } from './application/queries/list-course-exams.usecase';
-import { SAVED_EXAM_REPO } from './tokens';
+import { GetExamByIdUseCase } from './application/queries/get-exam-by-id.usecase';
+import { SAVED_EXAM_REPO,} from './tokens';
+import { SimpleCourseExamsProvider } from './infrastructure/http/providers/course-hardcoded-exams.provider';
 import { ApprovedExamsController } from './infrastructure/http/approved-exams.controller';
 import { TOKEN_SERVICE } from '../identity/tokens';
 
@@ -65,6 +67,7 @@ const DevTokenService = {
     ApproveExamCommandHandler,
     SaveApprovedExamUseCase,
     ListCourseExamsUseCase,
+    GetExamByIdUseCase,
     
     { provide: TOKEN_SERVICE, useValue: DevTokenService },
   ],

--- a/backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts
+++ b/backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts
@@ -1,10 +1,12 @@
 import { Body, Controller, Get, Param, Post, Req, UseGuards, BadRequestException, ForbiddenException, } from '@nestjs/common';
 import type { Request } from 'express';
 import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
-import { responseSuccess, responseBadRequest, responseForbidden, responseInternalServerError, } from 'src/shared/handler/http.handler';
+import { responseSuccess, responseBadRequest, responseForbidden, responseInternalServerError, responseNotFound, } from 'src/shared/handler/http.handler';
 import { SaveApprovedExamDto } from './dtos/save-approved-exam.dto';
 import { SaveApprovedExamUseCase } from '../../application/commands/save-approved-exam.usecase';
 import { ListCourseExamsUseCase } from '../../application/queries/list-course-exams.usecase';
+import { GetExamByIdUseCase } from '../../application/queries/get-exam-by-id.usecase';
+import * as crypto from 'crypto';
 
 const cid = (req: Request) => req.header('x-correlation-id') ?? crypto.randomUUID();
 const pathOf = (req: Request) => (req as any).originalUrl || req.url || '';
@@ -15,6 +17,7 @@ export class ApprovedExamsController {
   constructor(
     private readonly saveUseCase: SaveApprovedExamUseCase,
     private readonly listUseCase: ListCourseExamsUseCase,
+    private readonly getByIdUseCase: GetExamByIdUseCase,
   ) {}
 
   @Post('exams/approved')
@@ -60,4 +63,28 @@ export class ApprovedExamsController {
       return responseInternalServerError('Error interno', cid(req), msg, pathOf(req));
     }
   }
+
+
+  @Get('/exams/:examId')
+  async getExamById(@Param('examId') examId: string, @Req() req: Request) {
+    const user = (req as any).user as { sub: string } | undefined;
+    if (!user?.sub) {
+      return responseForbidden('Acceso no autorizado', cid(req), 'Falta token', pathOf(req));
+    }
+
+    try {
+      const data = await this.getByIdUseCase.execute({ examId, teacherId: user.sub });
+      return responseSuccess(cid(req), data, 'Examen recuperado', pathOf(req));
+    } catch (e: any) {
+      const msg = (e?.message ?? '').toString();
+      if (msg.includes('Acceso no autorizado')) {
+        return responseForbidden('Acceso no autorizado', cid(req), msg, pathOf(req));
+      }
+      if (msg.includes('Examen no encontrado')) {
+        return responseNotFound('Examen no encontrado', cid(req), msg, pathOf(req));
+      }
+      return responseInternalServerError('Error interno', cid(req), msg || 'Error obteniendo examen', pathOf(req));
+    }
+  }
+
 }

--- a/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts
@@ -120,4 +120,25 @@ export class ExamQuestionPrismaRepository implements ExamQuestionRepositoryPort 
       updatedAt: updated.updatedAt,
     };
   }
+
+    async listByExam(examId: string) {
+    const rows = await this.prisma.examQuestion.findMany({
+      where: { examId },
+      orderBy: { order: 'asc' },
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      examId: row.examId,
+      kind: row.kind as any,
+      text: row.text,
+      options: (row as any).options ?? undefined,
+      correctOptionIndex: row.correctOptionIndex ?? undefined,
+      correctBoolean: row.correctBoolean ?? undefined,
+      expectedAnswer: row.expectedAnswer ?? undefined,
+      order: row.order,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }));
+  }
+
 }

--- a/backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts
+++ b/backend/src/modules/exams/infrastructure/persistence/exam.prisma.repository.ts
@@ -5,6 +5,7 @@ import { Exam } from '../../domain/entities/exam.entity';
 import { Difficulty } from '../../domain/entities/difficulty.vo';
 import { PositiveInt } from '../../domain/entities/positive-int.vo';
 import { DistributionVO } from '../../domain/entities/distribution.vo';
+import { SavedExamDTO } from '../../domain/ports/saved-exam.repository.port';
 
 @Injectable()
 export class ExamPrismaRepository implements ExamRepositoryPort {
@@ -116,6 +117,23 @@ export class ExamPrismaRepository implements ExamRepositoryPort {
       data: { approvedAt: new Date() },
     });
     this.logger.log(`approve <- id=${id}`);
+  }
+
+    async findByExamId(examId: string): Promise<SavedExamDTO | null> {
+    const r = await this.prisma.savedExam.findUnique({
+      where: { examId },
+    });
+    if (!r) return null;
+    return {
+      id: r.id,
+      title: r.title,
+      content: r.content,
+      status: r.status as any,
+      courseId: r.courseId,
+      teacherId: r.teacherId,
+      createdAt: r.createdAt,
+      source: 'saved',
+    };
   }
 
 }

--- a/client/src/components/exams/ExamTable.tsx
+++ b/client/src/components/exams/ExamTable.tsx
@@ -11,23 +11,12 @@ const { Text } = Typography;
 type Props = {
   data: ExamSummary[];
   onEdit?: (exam?: ExamSummary) => void;
-  onChangeStatus?: (
-    exam: ExamSummary,
-    mode: 'now' | 'schedule' | 'draft',
-    whenIso?: string
-  ) => Promise<void> | void;
-  onToggleVisibility?: (exam: ExamSummary, next: 'visible' | 'hidden') => Promise<void> | void;
-  onDelete?: (exam: ExamSummary) => Promise<void> | void;
 };
 
 function fmt(dateIso?: string) {
   if (!dateIso) return '—';
   try {
-    return new Date(dateIso).toLocaleDateString('es-ES', {
-      year: 'numeric',
-      month: 'short',
-      day: '2-digit',
-    });
+    return new Date(dateIso).toLocaleDateString('es-ES', { year: 'numeric', month: 'short', day: '2-digit' });
   } catch {
     return '—';
   }
@@ -39,9 +28,7 @@ function StatusVisibility({ exam }: { exam: ExamSummary }) {
     return (
       <div className="flex items-center justify-center gap-2 flex-wrap" style={{ lineHeight: 1.2 }}>
         <Tag color="error">Oculto</Tag>
-        <span className="text-[12px] text-[var(--app-color-text-tertiary)]">
-          No visible al alumnado
-        </span>
+        <span className="text-[12px] text-[var(--app-color-text-tertiary)]">No visible al alumnado</span>
       </div>
     );
   }
@@ -49,9 +36,7 @@ function StatusVisibility({ exam }: { exam: ExamSummary }) {
     return (
       <div className="flex items-center justify-center gap-2 flex-wrap" style={{ lineHeight: 1.2 }}>
         <Tag color="success">Publicado</Tag>
-        <span className="text-[12px] text-[var(--app-color-text-tertiary)]">
-          Visible • Publicado: {fmt(exam.publishedAt)}
-        </span>
+        <span className="text-[12px] text-[var(--app-color-text-tertiary)]">Visible • Publicado: {fmt(exam.publishedAt)}</span>
       </div>
     );
   }
@@ -59,9 +44,7 @@ function StatusVisibility({ exam }: { exam: ExamSummary }) {
     return (
       <div className="flex items-center justify-center gap-2 flex-wrap" style={{ lineHeight: 1.2 }}>
         <Tag color="processing">Programado</Tag>
-        <span className="text-[12px] text-[var(--app-color-text-tertiary)]">
-          Visible • Programado: {fmt(exam.publishedAt)}
-        </span>
+        <span className="text-[12px] text-[var(--app-color-text-tertiary)]">Visible • Programado: {fmt(exam.publishedAt)}</span>
       </div>
     );
   }
@@ -73,9 +56,6 @@ function StatusVisibility({ exam }: { exam: ExamSummary }) {
   );
 }
 
-/* ===========================
-   Tipos + helpers de impresión
-   =========================== */
 type PrintableQuestion = {
   id: string;
   n: number;
@@ -229,7 +209,6 @@ function loadPrintableExam(exam: ExamSummary): PrintableExam | null {
   };
 }
 
-type PrintMode = 'questions_only' | 'questions_answers';
 function handleDownloadPdf(exam: ExamSummary, mode: PrintMode) {
   const printable = loadPrintableExam(exam);
   if (!printable) {
@@ -241,13 +220,7 @@ function handleDownloadPdf(exam: ExamSummary, mode: PrintMode) {
 }
 /* =========================== FIN helpers =========================== */
 
-export default function ExamTable({
-  data,
-  onEdit,
-  onChangeStatus,
-  onToggleVisibility,
-  onDelete,
-}: Props) {
+export default function ExamTable({ data, onEdit }: Props) {
   const toggleVisibility = useExamsStore((s: ExamsState) => s.toggleVisibility);
   const setVisibility = useExamsStore((s: ExamsState) => s.setVisibility);
   const setStatus = useExamsStore((s: ExamsState) => s.setStatus);
@@ -266,21 +239,8 @@ export default function ExamTable({
     setPublishOpen(true);
   };
 
-  const handleConfirmPublish = async () => {
+  const handleConfirmPublish = () => {
     if (!target) return;
-    if (onChangeStatus) {
-      const whenIso =
-        publishMode === 'schedule'
-          ? scheduleAt?.toDate().toISOString()
-          : publishMode === 'now'
-            ? new Date().toISOString()
-            : undefined;
-      await onChangeStatus(target, publishMode, whenIso);
-      setPublishOpen(false);
-      setTarget(null);
-      return;
-    }
-
     if (publishMode === 'now') {
       setStatus(target.id, 'published', new Date().toISOString());
       setVisibility(target.id, 'visible');
@@ -303,15 +263,11 @@ export default function ExamTable({
 
   const columns: ColumnsType<ExamSummary> = [
     {
-      title: (
-        <span style={{ display: 'block', textAlign: 'center', fontSize: token.fontSizeLG, fontWeight: 600 }}>
-          Título de Examen
-        </span>
-      ),
+      title: <span style={{ display: 'block', textAlign: 'center', fontSize: token.fontSizeLG, fontWeight: 600 }}>Título de Examen</span>,
       dataIndex: 'title',
       key: 'title',
       render: (title, record) => (
-        <div style={{ textAlign: 'center' }}>
+        <div style={{ textAlign:'center' }}>
           <Text strong style={{ color: token.colorPrimary, fontSize: token.fontSizeLG }} ellipsis>
             {title}
           </Text>
@@ -324,11 +280,7 @@ export default function ExamTable({
       ellipsis: true,
     },
     {
-      title: (
-        <span style={{ display: 'block', textAlign: 'center', fontSize: token.fontSizeLG, fontWeight: 600 }}>
-          Estado / Visibilidad
-        </span>
-      ),
+      title: <span style={{ display: 'block', textAlign: 'center', fontSize: token.fontSizeLG, fontWeight: 600 }}>Estado / Visibilidad</span>,
       key: 'status_visibility',
       align: 'center',
       render: (_, record) => <StatusVisibility exam={record} />,
@@ -340,11 +292,7 @@ export default function ExamTable({
       ellipsis: true,
     },
     {
-      title: (
-        <span style={{ display: 'block', textAlign: 'center', fontSize: token.fontSizeLG, fontWeight: 600 }}>
-          Acciones
-        </span>
-      ),
+      title: <span style={{ display: 'block', textAlign: 'center', fontSize: token.fontSizeLG, fontWeight: 600 }}>Acciones</span>,
       key: 'actions',
       align: 'right',
       render: (_, record) => {
@@ -355,43 +303,21 @@ export default function ExamTable({
         return (
           <Space size={6} wrap={false} style={{ whiteSpace: 'nowrap' }}>
             <Tooltip title="Editar">
-              <Button
-                type="text"
-                style={{ paddingInline: 6 }}
-                icon={<EditOutlined style={{ fontSize: 18 }} />}
-                onClick={() => onEdit?.(record)}
-                aria-label="Editar"
-              />
+              <Button type="text" style={{ paddingInline: 6 }} icon={<EditOutlined style={{ fontSize: 18 }} />} onClick={() => onEdit?.(record)} aria-label="Editar" />
             </Tooltip>
-
             <Tooltip title="Publicar / Programar / Borrador">
-              <Button
-                type="text"
-                style={{ paddingInline: 6 }}
-                icon={<UploadOutlined style={{ fontSize: 18 }} />}
-                onClick={() => openPublishModal(record)}
-                aria-label="Estado"
-              />
+              <Button type="text" style={{ paddingInline: 6 }} icon={<UploadOutlined style={{ fontSize: 18 }} />} onClick={() => openPublishModal(record)} aria-label="Estado" />
             </Tooltip>
-
             <Tooltip title={record.visibility === 'visible' ? 'Hacer privado' : 'Hacer público'}>
               <Button
                 type="text"
                 style={{ paddingInline: 6 }}
                 icon={record.visibility === 'visible' ? <EyeInvisibleOutlined style={{ fontSize: 18 }} /> : <EyeOutlined style={{ fontSize: 18 }} />}
-                onClick={() => {
-                  const next = record.visibility === 'visible' ? 'hidden' : 'visible';
-                  if (onToggleVisibility) {
-                    onToggleVisibility(record, next);
-                  } else {
-                    toggleVisibility(record.id);
-                  }
-                }}
+                onClick={() => toggleVisibility(record.id)}
                 aria-label="Visibilidad"
               />
             </Tooltip>
 
-            {/* Menú PDF con 2 opciones */}
             <Dropdown
               menu={{ items: menuItems.map(m => ({ key: m.key, label: m.label, onClick: m.onClick })) }}
               placement="bottomRight"
@@ -410,15 +336,7 @@ export default function ExamTable({
               okText="Eliminar"
               cancelText="Cancelar"
               okButtonProps={{ danger: true }}
-              onConfirm={async () => {
-                if (onDelete) {
-                  await onDelete(record);
-                  message.success('Examen eliminado');
-                } else {
-                  removeExam(record.id);
-                  message.success('Examen eliminado');
-                }
-              }}
+              onConfirm={() => { removeExam(record.id); message.success('Examen eliminado'); }}
             >
               <Tooltip title="Eliminar">
                 <Button type="text" danger style={{ paddingInline: 6 }} icon={<DeleteOutlined style={{ fontSize: 18 }} />} aria-label="Eliminar" />
@@ -435,7 +353,7 @@ export default function ExamTable({
       <Table
         rowKey="id"
         className="shadow-sm rounded-lg"
-        style={{ background: token.colorBgContainer, border: `1px solid ${token.colorBorderSecondary}`, padding: 10 }}
+        style={{ background: token.colorBgContainer, border: `1px solid ${token.colorBorderSecondary}` ,padding:10 }}
         columns={columns}
         dataSource={data}
         pagination={{ pageSize: 8, showSizeChanger: false }}
@@ -452,32 +370,17 @@ export default function ExamTable({
         open={publishOpen}
         onOk={handleConfirmPublish}
         onCancel={() => setPublishOpen(false)}
-        okText={
-          publishMode === 'now'
-            ? 'Publicar'
-            : publishMode === 'schedule'
-              ? 'Programar'
-              : 'Guardar como borrador'
-        }
+        okText={publishMode === 'now' ? 'Publicar' : publishMode === 'schedule' ? 'Programar' : 'Guardar como borrador'}
         cancelText="Cancelar"
       >
-        <Radio.Group
-          value={publishMode}
-          onChange={(e) => setPublishMode(e.target.value)}
-          className="flex flex-col gap-2"
-        >
+        <Radio.Group value={publishMode} onChange={(e) => setPublishMode(e.target.value)} className="flex flex-col gap-2">
           <Radio value="now">Publicar ahora</Radio>
           <Radio value="schedule">Programar</Radio>
           <Radio value="draft">Borrador</Radio>
         </Radio.Group>
         {publishMode === 'schedule' && (
           <div className="mt-3">
-            <DatePicker
-              showTime
-              style={{ width: '100%' }}
-              value={scheduleAt as any}
-              onChange={(d) => setScheduleAt(d)}
-            />
+            <DatePicker showTime style={{ width: '100%' }} value={scheduleAt as any} onChange={(d) => setScheduleAt(d)} />
           </div>
         )}
       </Modal>

--- a/client/src/components/exams/ExamTable.tsx
+++ b/client/src/components/exams/ExamTable.tsx
@@ -1,9 +1,10 @@
-import { Button, Table, Tag, Tooltip, Typography, theme, Modal, DatePicker, Radio, message, Space, Popconfirm } from 'antd';
-import { EyeOutlined, EyeInvisibleOutlined, EditOutlined, UploadOutlined, FilePdfOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Button, Table, Tag, Tooltip, Typography, theme, Modal, DatePicker, Radio, message, Space, Popconfirm, Dropdown } from 'antd';
+import { EyeOutlined, EyeInvisibleOutlined, EditOutlined, UploadOutlined, FilePdfOutlined, DeleteOutlined, DownOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import { useExamsStore, type ExamSummary, type ExamsState } from '../../store/examsStore';
+import { readJSON } from '../../services/storage/localStorage';
 
 const { Text } = Typography;
 
@@ -72,43 +73,173 @@ function StatusVisibility({ exam }: { exam: ExamSummary }) {
   );
 }
 
-function downloadExamPdf(exam: ExamSummary) {
+/* ===========================
+   Tipos + helpers de impresión
+   =========================== */
+type PrintableQuestion = {
+  id: string;
+  n: number;
+  source: 'ai' | 'manual';
+  type: 'multiple_choice' | 'true_false' | 'open_analysis' | 'open_exercise';
+  text: string;
+  options?: string[];
+  correctOptionIndex?: number;
+  correctBoolean?: boolean;
+  expectedAnswer?: string;
+  answer?: string;
+};
+
+type PrintableExam = {
+  examId: string;
+  title: string;
+  subject: string;
+  teacher: string;
+  createdAt?: string;
+  questions: PrintableQuestion[];
+};
+
+type PrintMode = 'questions_only' | 'questions_answers';
+
+function escapeHtml(s: string) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function answerOf(q: PrintableQuestion): string | undefined {
+  if (q.answer && String(q.answer).trim()) return q.answer;
+  if (typeof q.correctBoolean === 'boolean') return q.correctBoolean ? 'Verdadero' : 'Falso';
+  if (typeof q.correctOptionIndex === 'number' && Array.isArray(q.options)) {
+    const i = q.correctOptionIndex;
+    if (i >= 0 && i < q.options.length) return q.options[i];
+  }
+  if (q.expectedAnswer && String(q.expectedAnswer).trim()) return q.expectedAnswer;
+  return undefined;
+}
+
+function renderQuestion(q: PrintableQuestion, withAnswers: boolean): string {
+  const text = escapeHtml(q.text);
+  let html = `<div class="q">
+    <div class="q-num">(${q.n})</div>
+    <div class="q-body">
+      <div class="q-text">${text}</div>`;
+
+  if (q.type === 'multiple_choice' && Array.isArray(q.options) && q.options.length) {
+    html += `<ol class="q-options">`;
+    q.options.forEach((opt) => {
+      html += `<li>${escapeHtml(opt)}</li>`;
+    });
+    html += `</ol>`;
+  }
+
+  if (withAnswers) {
+    const ans = answerOf(q);
+    html += `<div class="q-answer"><b>Respuesta:</b> ${ans ? escapeHtml(ans) : '—'}</div>`;
+  }
+
+  html += `</div></div>`;
+  return html;
+}
+
+function buildPlantillaHtml(data: PrintableExam, mode: PrintMode): string {
+  const withAnswers = mode === 'questions_answers';
+  const total = data.questions?.length ?? 0;
+
+  const questionsHtml = (data.questions || [])
+    .map(q => renderQuestion(q, withAnswers))
+    .join('');
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>${escapeHtml(data.title)}</title>
+  <style>
+    @page { size: A4; margin: 24mm 18mm 18mm 18mm; }
+    body { font-family: Arial, Helvetica, sans-serif; color: #111; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6mm; }
+    .box { border: 1px solid #999; border-radius: 6px; padding: 6mm; }
+    .note { font-size: 9pt; color: #333; line-height: 1.35; white-space: pre-wrap; }
+    .student { margin-top: 6mm; }
+    .student .field { display: grid; grid-template-columns: 22mm 1fr; gap: 3mm; margin: 1.5mm 0; }
+    .q { display: grid; grid-template-columns: 8mm 1fr; gap: 3mm; margin: 5mm 0; page-break-inside: avoid; }
+    .q-num { font-weight: bold; }
+    .q-text { margin-bottom: 2mm; }
+    .q-options { margin: 0 0 2mm 18px; }
+    .q-answer { margin-top: 2mm; color: #0a4; }
+    .footer { margin-top: 10mm; font-size: 9pt; color: #444; }
+    .hdr { border-bottom: 2px solid #111; padding-bottom: 4mm; margin-bottom: 6mm; font-weight: 700;}
+  </style>
+</head>
+<body>
+  <div class="hdr">PRUEBA VÁLIDA PARA LA CALIFICACIÓN: &nbsp; parcial 1a &nbsp;&nbsp; parcial 2a &nbsp;&nbsp; final</div>
+
+  <div class="grid">
+    <div class="box">
+      <div><b>MATERIA:</b> ${escapeHtml(data.subject || '—')}</div>
+      <div><b>DOCENTE:</b> ${escapeHtml(data.teacher || '—')}</div>
+      <div><b>Título:</b> ${escapeHtml(data.title)}</div>
+      <div><b>Puntaje total de la prueba:</b> 100 puntos</div>
+      <div><b>Fecha:</b> ${escapeHtml(new Date(data.createdAt || Date.now()).toLocaleDateString('es-ES'))}</div>
+      <div><b>Tipo de impresión:</b> ${withAnswers ? 'Preguntas + Respuestas' : 'Solo preguntas'}</div>
+      <div><b>Cantidad de preguntas:</b> ${total}</div>
+    </div>
+    <div class="box note">
+      ACTÚA CON HONESTIDAD ACADÉMICA
+      El fraude académico en exámenes, trabajos, prácticas o cualquier otra actividad de la materia, ya sea por intención o ejecución, es sancionado con la reprobación automática de la materia.
+      Cualquier sanción por fraude académico implica la pérdida del derecho a acceder al cuadro de honor y a la graduación con honores. La reincidencia puede concluir con la expulsión de la Universidad.
+    </div>
+  </div>
+
+  <div class="student box">
+    <div><b>DATOS QUE DEBE COMPLETAR EL ESTUDIANTE:</b></div>
+    <div class="field"><div>Código:</div><div>______________________________</div></div>
+    <div class="field"><div>Nombre:</div><div>______________________________</div></div>
+  </div>
+
+  <div class="questions">
+    ${questionsHtml}
+  </div>
+
+  <div class="footer">Generado — Sistema de Gestión de Exámenes</div>
+
+  <script>window.onload = () => window.print()</script>
+</body>
+</html>`;
+}
+
+function openPrint(html: string) {
   const w = window.open('', '_blank');
   if (!w) return;
-  const html = `
-    <!doctype html>
-    <html>
-      <head>
-        <meta charset="utf-8"/>
-        <title>${exam.title}</title>
-        <style>
-          body{font-family:Arial,Helvetica,sans-serif;padding:24px}
-          h1{margin:0 0 8px 0}
-          .meta{color:#666;margin-bottom:16px}
-          .box{border:1px solid #ddd;border-radius:8px;padding:16px}
-          .row{margin:6px 0}
-        </style>
-      </head>
-      <body>
-        <h1>${exam.title}</h1>
-        <div class="meta">Creado: ${fmt(exam.createdAt)} • Preguntas: ${exam.totalQuestions}</div>
-        <div class="box">
-          <div class="row">Estado: ${exam.status}</div>
-          <div class="row">Visibilidad: ${exam.visibility}</div>
-          <div class="row">Fecha publicación/programación: ${fmt(exam.publishedAt)}</div>
-          <div class="row">Selección múltiple: ${exam.counts.multiple_choice}</div>
-          <div class="row">Verdadero/Falso: ${exam.counts.true_false}</div>
-          <div class="row">Análisis abierto: ${exam.counts.open_analysis}</div>
-          <div class="row">Ejercicio abierto: ${exam.counts.open_exercise}</div>
-        </div>
-        <script>window.onload=()=>window.print()</script>
-      </body>
-    </html>
-  `;
   w.document.open();
   w.document.write(html);
   w.document.close();
 }
+
+function loadPrintableExam(exam: ExamSummary): PrintableExam | null {
+  const stored = readJSON<PrintableExam>(`exam:content:${exam.id}`);
+  if (!stored || !Array.isArray(stored.questions) || stored.questions.length === 0) return null;
+  return {
+    examId: stored.examId || exam.id,
+    title: stored.title || exam.title,
+    subject: stored.subject || exam.className || '—',
+    teacher: stored.teacher || '—',
+    createdAt: stored.createdAt || exam.createdAt,
+    questions: stored.questions.map((q, i) => ({ ...q, n: q.n || i + 1 })),
+  };
+}
+
+type PrintMode = 'questions_only' | 'questions_answers';
+function handleDownloadPdf(exam: ExamSummary, mode: PrintMode) {
+  const printable = loadPrintableExam(exam);
+  if (!printable) {
+    message.error('No se encontró el contenido del examen. Vuelve a guardarlo desde la pantalla de resultados.');
+    return;
+  }
+  const html = buildPlantillaHtml(printable, mode);
+  openPrint(html);
+}
+/* =========================== FIN helpers =========================== */
 
 export default function ExamTable({
   data,
@@ -216,79 +347,86 @@ export default function ExamTable({
       ),
       key: 'actions',
       align: 'right',
-      render: (_, record) => (
-        <Space size={6} wrap={false} style={{ whiteSpace: 'nowrap' }}>
-          <Tooltip title="Editar">
-            <Button
-              type="text"
-              style={{ paddingInline: 6 }}
-              icon={<EditOutlined style={{ fontSize: 18 }} />}
-              onClick={() => onEdit?.(record)}
-              aria-label="Editar"
-            />
-          </Tooltip>
-          <Tooltip title="Publicar / Programar / Borrador">
-            <Button
-              type="text"
-              style={{ paddingInline: 6 }}
-              icon={<UploadOutlined style={{ fontSize: 18 }} />}
-              onClick={() => openPublishModal(record)}
-              aria-label="Estado"
-            />
-          </Tooltip>
-          <Tooltip title={record.visibility === 'visible' ? 'Hacer privado' : 'Hacer público'}>
-            <Button
-              type="text"
-              style={{ paddingInline: 6 }}
-              icon={
-                record.visibility === 'visible' ? (
-                  <EyeInvisibleOutlined style={{ fontSize: 18 }} />
-                ) : (
-                  <EyeOutlined style={{ fontSize: 18 }} />
-                )
-              }
-              onClick={() => {
-                const next = record.visibility === 'visible' ? 'hidden' : 'visible';
-                if (onToggleVisibility) {
-                  onToggleVisibility(record, next);
+      render: (_, record) => {
+        const menuItems = [
+          { key: 'q', label: 'Descargar — Solo preguntas', onClick: () => handleDownloadPdf(record, 'questions_only') },
+          { key: 'qa', label: 'Descargar — Preguntas y respuestas', onClick: () => handleDownloadPdf(record, 'questions_answers') },
+        ];
+        return (
+          <Space size={6} wrap={false} style={{ whiteSpace: 'nowrap' }}>
+            <Tooltip title="Editar">
+              <Button
+                type="text"
+                style={{ paddingInline: 6 }}
+                icon={<EditOutlined style={{ fontSize: 18 }} />}
+                onClick={() => onEdit?.(record)}
+                aria-label="Editar"
+              />
+            </Tooltip>
+
+            <Tooltip title="Publicar / Programar / Borrador">
+              <Button
+                type="text"
+                style={{ paddingInline: 6 }}
+                icon={<UploadOutlined style={{ fontSize: 18 }} />}
+                onClick={() => openPublishModal(record)}
+                aria-label="Estado"
+              />
+            </Tooltip>
+
+            <Tooltip title={record.visibility === 'visible' ? 'Hacer privado' : 'Hacer público'}>
+              <Button
+                type="text"
+                style={{ paddingInline: 6 }}
+                icon={record.visibility === 'visible' ? <EyeInvisibleOutlined style={{ fontSize: 18 }} /> : <EyeOutlined style={{ fontSize: 18 }} />}
+                onClick={() => {
+                  const next = record.visibility === 'visible' ? 'hidden' : 'visible';
+                  if (onToggleVisibility) {
+                    onToggleVisibility(record, next);
+                  } else {
+                    toggleVisibility(record.id);
+                  }
+                }}
+                aria-label="Visibilidad"
+              />
+            </Tooltip>
+
+            {/* Menú PDF con 2 opciones */}
+            <Dropdown
+              menu={{ items: menuItems.map(m => ({ key: m.key, label: m.label, onClick: m.onClick })) }}
+              placement="bottomRight"
+              trigger={['click']}
+            >
+              <Tooltip title="Descargar PDF">
+                <Button type="text" style={{ paddingInline: 6 }} icon={<FilePdfOutlined style={{ fontSize: 18 }} />} aria-label="Descargar PDF">
+                  <DownOutlined style={{ fontSize: 10, marginLeft: 4 }} />
+                </Button>
+              </Tooltip>
+            </Dropdown>
+
+            <Popconfirm
+              title="Eliminar examen"
+              description="Esta acción no se puede deshacer."
+              okText="Eliminar"
+              cancelText="Cancelar"
+              okButtonProps={{ danger: true }}
+              onConfirm={async () => {
+                if (onDelete) {
+                  await onDelete(record);
+                  message.success('Examen eliminado');
                 } else {
-                  (toggleVisibility as any)(record.id); 
+                  removeExam(record.id);
+                  message.success('Examen eliminado');
                 }
               }}
-              aria-label="Visibilidad"
-            />
-          </Tooltip>
-          <Tooltip title="Descargar PDF">
-            <Button
-              type="text"
-              style={{ paddingInline: 6 }}
-              icon={<FilePdfOutlined style={{ fontSize: 18 }} />}
-              onClick={() => downloadExamPdf(record)}
-              aria-label="Descargar PDF"
-            />
-          </Tooltip>
-          <Popconfirm
-            title="Eliminar examen"
-            description="Esta acción no se puede deshacer."
-            okText="Eliminar"
-            cancelText="Cancelar"
-            okButtonProps={{ danger: true }}
-            onConfirm={async () => {
-              if (onDelete) {
-                await onDelete(record);
-                message.success('Examen eliminado');
-              } else {
-                removeExam(record.id);
-                message.success('Examen eliminado');
-              }
-            }}
-          >
-            <Tooltip title="Eliminar">
-              <Button type="text" danger style={{ paddingInline: 6 }} icon={<DeleteOutlined style={{ fontSize: 18 }} />} aria-label="Eliminar" />
-            </Tooltip>
-          </Popconfirm>
-        </Space>
-      ),
+            >
+              <Tooltip title="Eliminar">
+                <Button type="text" danger style={{ paddingInline: 6 }} icon={<DeleteOutlined style={{ fontSize: 18 }} />} aria-label="Eliminar" />
+              </Tooltip>
+            </Popconfirm>
+          </Space>
+        );
+      },
     },
   ];
 

--- a/client/src/pages/exams/AiResults.tsx
+++ b/client/src/pages/exams/AiResults.tsx
@@ -5,7 +5,7 @@ import QuestionCard from '../../components/ai/QuestionCard';
 import type { GeneratedQuestion } from '../../services/exams.service';
 import { useExamsStore } from '../../store/examsStore';
 import { useNavigate } from 'react-router-dom';
-
+import { readJSON, saveJSON } from '../../services/storage/localStorage';
 
 const { Title, Text } = Typography;
 
@@ -70,12 +70,192 @@ export default function AiResults({
     }
   };
 
+  function optToString(opt: any): string {
+    if (typeof opt === 'string') return opt;
+    if (!opt || typeof opt !== 'object') return '';
+    return (
+      opt.text ??
+      opt.label ??
+      opt.content ??
+      opt.option ??
+      opt.value ??
+      ''
+    );
+  }
+
+  function optionsAsStrings(q: any): string[] {
+    if (!q?.options) return [];
+    if (Array.isArray(q.options)) return q.options.map(optToString).filter(Boolean);
+    return [];
+  }
+
+  function letterToIndex(letter: any): number | undefined {
+    const s = String(letter ?? '').trim().toLowerCase();
+    const map: Record<string, number> = { a:0, b:1, c:2, d:3, e:4, f:5 };
+    return s in map ? map[s] : undefined;
+  }
+
+  function numberToIndex(n: any): number | undefined {
+    const v = Number(String(n ?? '').trim());
+    if (!Number.isFinite(v)) return undefined;
+    const i = v - 1;
+    return i >= 0 ? i : undefined;
+  }
+
+  function parseBooleanAnswer(ans: any): boolean | undefined {
+    if (typeof ans === 'boolean') return ans;
+    const s = String(ans ?? '').trim().toLowerCase();
+    if (!s) return undefined;
+    if (['v', 'verdadero', 'true', 'si', 'sí', 's', '1'].includes(s)) return true;
+    if (['f', 'falso', 'false', 'no', 'n', '0'].includes(s)) return false;
+    return undefined;
+  }
+
+  function findCorrectIndexFromOptionsArray(q: any): number | undefined {
+    if (!Array.isArray(q?.options)) return undefined;
+    const byFlag = q.options.findIndex((o: any) => o?.correct === true || o?.isCorrect === true);
+    return byFlag >= 0 ? byFlag : undefined;
+  }
+
+  function normalizeMCQ(q: any, idx: number) {
+    const base = {
+      id: q.id,
+      n: idx + 1,
+      source: q.id?.startsWith('manual_') ? ('manual' as const) : ('ai' as const),
+      type: q.type,
+      text: q.text ?? '',
+    };
+
+    const opts = optionsAsStrings(q);
+    let correctIndex: number | undefined =
+      q.correctOptionIndex ??
+      q.correctIndex ??
+      q.answerIndex ??
+      undefined;
+
+    if (correctIndex === undefined) {
+      correctIndex =
+        letterToIndex(q.correctOptionLetter) ??
+        letterToIndex(q.answerLetter) ??
+        letterToIndex(q.correct) ??
+        letterToIndex(q.answer) ??
+        undefined;
+    }
+
+    if (correctIndex === undefined) {
+      correctIndex =
+        numberToIndex(q.correctOptionNumber) ??
+        numberToIndex(q.answerNumber) ??
+        numberToIndex(q.correct) ??
+        numberToIndex(q.answer) ??
+        undefined;
+    }
+
+    if (correctIndex === undefined) {
+      correctIndex = findCorrectIndexFromOptionsArray(q);
+    }
+
+    let answerText: string | undefined = (q.answer && String(q.answer).trim()) || undefined;
+    if (typeof correctIndex === 'number' && Array.isArray(opts) && opts[correctIndex]) {
+      answerText = opts[correctIndex]; // priorizamos el texto de la opción correcta
+    } else if (!answerText && Array.isArray(opts) && opts.length) {
+      const i = opts.findIndex(o => o.trim().toLowerCase() === String(q.correctOptionText ?? q.correctAnswer ?? q.solution ?? '').trim().toLowerCase());
+      if (i >= 0) {
+        correctIndex = i;
+        answerText = opts[i];
+      }
+    }
+
+    if (!answerText && typeof q.answer === 'string' && opts.length) {
+      const i = opts.findIndex(o => o.trim().toLowerCase() === q.answer.trim().toLowerCase());
+      if (i >= 0) {
+        correctIndex = i;
+        answerText = opts[i];
+      }
+    }
+
+    return {
+      ...base,
+      options: opts,
+      correctOptionIndex: typeof correctIndex === 'number' ? correctIndex : undefined,
+      answer: answerText,
+    };
+  }
+
+  function normalizeTrueFalse(q: any, idx: number) {
+    const base = {
+      id: q.id,
+      n: idx + 1,
+      source: q.id?.startsWith('manual_') ? ('manual' as const) : ('ai' as const),
+      type: q.type,
+      text: q.text ?? '',
+    };
+
+    let bool =
+      parseBooleanAnswer(q.answer) ??
+      parseBooleanAnswer(q.correctBoolean) ??
+      parseBooleanAnswer(q.correct) ??
+      parseBooleanAnswer(q.truth) ??
+      parseBooleanAnswer(q.isTrue) ??
+      undefined;
+
+    return {
+      ...base,
+      correctBoolean: bool,
+      answer: typeof bool === 'boolean' ? (bool ? 'Verdadero' : 'Falso') : (q.answer ?? undefined),
+    };
+  }
+
+  function normalizeOpen(q: any, idx: number) {
+    const base = {
+      id: q.id,
+      n: idx + 1,
+      source: q.id?.startsWith('manual_') ? ('manual' as const) : ('ai' as const),
+      type: q.type,
+      text: q.text ?? '',
+    };
+
+    const answer =
+      q.expectedAnswer ??
+      q.answer ??
+      q.modelAnswer ??
+      q.sampleAnswer ??
+      q.solution ??
+      q.correct ??
+      undefined;
+
+    return { ...base, expectedAnswer: answer, answer };
+  }
+
+  function mapQuestionForPrint(q: GeneratedQuestion, idx: number) {
+    if (q.type === 'multiple_choice') return normalizeMCQ(q, idx);
+    if (q.type === 'true_false') return normalizeTrueFalse(q, idx);
+    return normalizeOpen(q, idx);
+  }
+
   const handleSave = async () => {
     setSaveLoading(true);
     try {
       await onSave();
-      addFromQuestions({ title: subject || 'Examen', questions, publish: true });
-       navigate('/exams', { replace: true })
+      const summary = addFromQuestions({ title: subject || 'Examen', questions, publish: true });
+
+      const printable = {
+        examId: summary.id,
+        title: summary.title,
+        subject: subject || summary.className || '—',
+        teacher: '—',
+        createdAt: summary.createdAt || new Date().toISOString(),
+        questions: questions.filter(q => q.include).map(mapQuestionForPrint),
+      };
+      saveJSON(`exam:content:${summary.id}`, printable);
+
+      const index = readJSON<string[]>(`exam:content:index`) || [];
+      if (!index.includes(summary.id)) {
+        index.push(summary.id);
+        saveJSON(`exam:content:index`, index);
+      }
+
+      navigate('/exams', { replace: true });
     } finally {
       setSaveLoading(false);
     }


### PR DESCRIPTION
# PR: Integración Validación + Normalización de Exámenes IA + Listado por Curso + Endpoint GET por ID + Preparación de Eliminación (UI)

Este PR unifica mejoras de **frontend** y **backend** para robustecer la creación, consulta, normalización, impresión y (preparación de) eliminación de exámenes.

---

## Resumen Ejecutivo

- **Frontend**
  - Validación y **normalización** de preguntas IA/manuales.
  - **Impresión** con plantilla (Solo preguntas | Preguntas+Respuestas).
  - Panel de **Gestión de Exámenes por Curso** (US-58) usando `ExamTable`.
  - **Preparación de eliminación** en UI con rutas alternativas y *rollback* (requiere endpoint BE definitivo).

- **Backend**
  - Nuevo endpoint **GET `/exams/:examId`** (docente, con ownership).
  - **Relación Prisma** `SavedExam.examId → Exam.id` (1–1) para autorización y consulta.
  - **Listado por curso** expuesto/ajustado para `ExamTable`.

- **Breaking changes**
  - `SavedExam.examId` requerido y único → se necesita **backfill**.
  - Solo se consultan exámenes **guardados** (vinculados a `SavedExam`).

---

## Archivos Modificados (Frontend)

- `client/src/utils/aiValidation.ts`
- `client/src/pages/exams/ai-utils.ts`
- `client/src/services/exams.service.ts`
- `client/src/pages/exams/AiQuestionsPage.tsx`
- `client/src/pages/exams/ExamCreatePage.tsx`
- `client/src/pages/exams/AiResults.tsx`
- `client/src/components/exams/ExamTable.tsx`
- `client/src/pages/academic_management/CourseDetailPage.tsx`
- **Nuevo:** `client/src/pages/courses/CourseExamsPanel.tsx`

---

## Cambios Realizados (Frontend)

### `client/src/utils/aiValidation.ts`
- **Añadidos:** `PLACEHOLDER_SIGNATURES` y `validateAIQuestion()`:
  - Detecta placeholders y estructura mínima (texto, opciones, etc.).

### `client/src/pages/exams/ai-utils.ts`
- **Helpers de normalización:**  
  - Convertir opciones a `string`, map letra → índice, parseo robusto de booleanos.  
  - `mapQuestionForPrint()` → unifica formato imprimible.

### `client/src/services/exams.service.ts`
- **Generación IA:** reintentos, variaciones de prompt; retorno de `correctOptionIndex/answer` cuando exista.
- **Eliminación (preparación):** `deleteExamByCandidates(courseId, candidates)`  
  - Normaliza IDs (numérico/UUID), intenta múltiples rutas (`DELETE`, `POST /delete`, `soft-delete`) en:
    - Por curso: `/courses/:courseId/exams/:id`
    - General: `/exams/:id`, `/exams/approved/:id`
    - Guardados: `/saved-exams/:id`, `/exams/quick-save/:id` (si existiera)
  - Éxito en el primer 2xx, *rollback* si todos fallan.

### `client/src/pages/exams/AiQuestionsPage.tsx`
- **Paralelismo:** `Promise.allSettled`.  
- **Validación** por pregunta antes de aceptarla.

### `client/src/pages/exams/ExamCreatePage.tsx`
- **Manual:** IDs `manual_*`, `source: 'manual'`, captura respuesta docente para normalización.
- **Navegación:** soporte `?courseId=`.

### `client/src/pages/exams/AiResults.tsx`
- **Normalización al guardar**: mapeo por tipo (MCQ/VF/abiertas).
- **Persistencia**: `localStorage` → `exam:content:<examId>` (incluye respuesta final IA o manual).

### `client/src/components/exams/ExamTable.tsx`
- **PDF → Dropdown** con:
  - **Solo preguntas**
  - **Preguntas + Respuestas**
- **Impresión:** `buildPlantillaHtml()` + `window.print()`.
- **Layout A4** alineado a `Plantillaexam.pdf`:
  - Encabezado “PRUEBA VÁLIDA…”, cajas Materia/Docente, puntaje, fecha, “Código/Nombre”, nota de honestidad, listado.
- **Eliminar:** conecta el ícono de basura con `onDelete` del panel.

### `client/src/pages/academic_management/CourseDetailPage.tsx` + **Nuevo** `CourseExamsPanel.tsx` (US-58)
- Panel **Gestión de Exámenes** que:
  - Llama `listCourseExams(courseId)` y renderiza `ExamTable` o *empty state* con “Crear Examen”.
  - Encapsula loader y conteo → el padre no maneja `hasExams`.

---

## Resultado (Frontend)

- Se **resuelve** bug de preguntas IA repetidas/placeholder.  
- Se **garantiza** coherencia y trazabilidad de origen (IA/manual).  
- Se **incorpora** impresión con plantilla (dos modos).  
- **UI de eliminación** lista (optimista + rollback); requiere endpoint BE definitivo para borrar en BD.

---

## Archivos Modificados (Backend)

- `backend/src/modules/exams/infrastructure/http/approved-exams.controller.ts`
- `backend/src/modules/exams/application/queries/get-exam-by-id.usecase.ts`
- `backend/src/modules/exams/application/queries/list-course-exams.usecase.ts`
- `backend/src/modules/exams/infrastructure/http/exams.controller.ts` *(si aplica en tu árbol)*
- `backend/src/modules/exams/exams.module.ts`
- `backend/src/modules/exams/domain/ports/saved-exam.repository.port.ts`
- `backend/src/modules/exams/infrastructure/persistence/saved-exam.prisma.repository.ts`
- `backend/src/modules/exams/infrastructure/persistence/exam-question.prisma.repository.ts`
- `backend/prisma/schema.prisma`

---

## Cambios Realizados (Backend)

### **Añadido**
- **Endpoint:** `GET /exams/:examId`  
  - Devuelve título, fecha, estado, metadatos y **preguntas con respuestas**.  
  - **Docentes** únicamente (JwtAuthGuard + ownership por `teacherId`).  
  - Errores:
    - `404 Examen no encontrado`
    - `403 Acceso no autorizado`

- **Use Case:** `GetExamByIdUseCase`  
  - Lee `Exam` + `ExamQuestion` y enriquece con `SavedExam` (title/status/createdAt).  
  - Calcula `distribution` desde `mcqCount/trueFalseCount/openAnalysisCount/openExerciseCount`.

- **Repositorios:**  
  - `SavedExamRepository.findByExamId(examId)`  
  - `ExamQuestionRepository.listByExam(examId)`

- **Listado por curso (US-58):**  
  - Expuesto/ajustado el **endpoint y use case** para `ExamTable`.

### **Actualizado**
- **`ApprovedExamsController`**: agrega `GET /exams/:examId`.  
- **`exams.module.ts`**: registra `GetExamByIdUseCase` y dependencias.  
- **DTOs & Ports**: `SavedExamReadModel` con `status` restringido (`'Guardado' | 'Publicado'`).  
- **Prisma**: relación `SavedExam.examId → Exam.id` (1–1, `@unique`, FK, `onDelete: CASCADE`).

### **Eliminado**
- N/A (sin archivos eliminados).  
- **Removed** acceso directo a `base.distribution` (no existía en entidad).

---

## Breaking Changes

- **BD:**  
  - Nueva columna **obligatoria** `examId` en `SavedExam` (`UNIQUE` + FK a `Exam.id`).  
  - Se requiere **backfill** de registros existentes para asignar `examId`.  
    - Sin vínculo → `/exams/:id` devuelve `404`.

- **Contrato de API:**  
  - Solo se consultan exámenes **guardados** (tienen fila en `SavedExam` para autorización).  
  - Exámenes en `Exam` **sin** `SavedExam` **no** son accesibles por `/api/exams/:id`.

- **UI Eliminación:**  
  - Preparada en FE; **no hay** endpoint BE definitivo hoy → eliminación efectiva dependerá del endpoint que se exponga.

---

## Pasos de Migración y Regeneración

> **Estrategia recomendada**: Nullable → backfill → Not Null

1) **Agregar columna nullable** y FK (si aún no existe):
```bash
npx prisma migrate reset
npx prisma generate
npx prisma migrate dev o npx migrate db push
npm run seed
```

Endpoints Clave

*   **GET** /exams/:examId → Docente; requiere SavedExam.examId = :examId y SavedExam.teacherId = user.sub.
    
*   **GET** /courses/:courseId/exams → Listado por curso para ExamTable (US-58).



